### PR TITLE
Add backing field for NumberingScheme

### DIFF
--- a/System.Device.Gpio/GpioController.cs
+++ b/System.Device.Gpio/GpioController.cs
@@ -19,6 +19,7 @@ namespace System.Device.Gpio
         static readonly object _syncLock = new object();
 
         private bool _disposedValue;
+        private PinNumberingScheme _numberingScheme;
 
         /// <summary>
         /// Initializes a new instance of the System.Device.Gpio.GpioController class that
@@ -42,7 +43,7 @@ namespace System.Device.Gpio
         /// <summary>
         /// The numbering scheme used to represent pins provided by the controller.
         /// </summary>
-        public PinNumberingScheme NumberingScheme { get; internal set; }
+        public PinNumberingScheme NumberingScheme { get => _numberingScheme; internal set => _numberingScheme = value; }
 
         /// <summary>
         /// The number of pins provided by the controller.

--- a/System.Device.Gpio/Properties/AssemblyInfo.cs
+++ b/System.Device.Gpio/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.0.5")]
+[assembly: AssemblyNativeVersion("100.1.0.6")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 


### PR DESCRIPTION
## Description
- Add backing field for NumberingScheme
- Bump AssemblyNativeVersion to 100.1.0.6.

## Motivation and Context
- This was using an auto-property which was causing issues in native assembly declaration.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
